### PR TITLE
WIP - Add an EJSON store (decrypt only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ commands:
           name: install dependencies
           command: |
             pipenv install --dev --skip-lock
-            pipenv run pip install -e .
 
       - save_cache:
           paths:

--- a/Pipfile
+++ b/Pipfile
@@ -11,5 +11,6 @@ httpretty = "*"
 pylint = "*"
 pyreleaser = "*"
 mypy = "*"
+"e1839a8" = {path = ".", extras = ["ejson"], editable = true}
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8aebaf618766239e750dbe22287fabed6a9ba9d5b4c420d005d2f7ae81c49388"
+            "sha256": "e40e74d4bb5c166b30348cbc99491f200175bd89d9d22d764c4d2e0e9bbe8a02"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -41,6 +41,13 @@
                 "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
             ],
             "version": "==3.0.2"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:90f1d559512fc073483fe573ef5ceb39bf6ad3d39edc98dc55178a2b2b176fa3",
+                "sha256:d1c398969c478d336f767ba02040fa22617333293fb0b8968e79b16028dfee35"
+            ],
+            "version": "==2.1.0"
         },
         "certifi": {
             "hashes": [
@@ -141,11 +148,45 @@
             ],
             "version": "==0.14"
         },
+        "e1839a8": {
+            "editable": true,
+            "extras": [
+                "ejson"
+            ],
+            "path": "."
+        },
         "future": {
             "hashes": [
                 "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
             ],
             "version": "==0.16.0"
+        },
+        "google-api-python-client": {
+            "hashes": [
+                "sha256:5d5cb02c6f3112c68eed51b74891a49c0e35263380672d662f8bfe85b8114d7c",
+                "sha256:7cc47cf80b25ecd7f3d917ea247bb6c62587514e40604ae29c47c0e4ebd1174b"
+            ],
+            "version": "==1.7.4"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:9ca363facbf2622d9ba828017536ccca2e0f58bd15e659b52f312172f8815530",
+                "sha256:a4cf9e803f2176b5de442763bd339b313d3f1ed3002e3e1eb6eec1d7c9bbc9b4"
+            ],
+            "version": "==1.5.1"
+        },
+        "google-auth-httplib2": {
+            "hashes": [
+                "sha256:098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445",
+                "sha256:f1c437842155680cf9918df9bc51c1182fda41feef88c34004bd1978c8157e08"
+            ],
+            "version": "==0.0.3"
+        },
+        "httplib2": {
+            "hashes": [
+                "sha256:e71daed9a0e6373642db61166fa70beecc9bf04383477f84671348c02a04cbdf"
+            ],
+            "version": "==0.11.3"
         },
         "httpretty": {
             "hashes": [
@@ -254,6 +295,42 @@
             ],
             "version": "==1.7.0"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:0ad0fe0593dde1e599cac0bf65bb1a4ec663032f0bc68ee44850db4251e8c501",
+                "sha256:13794d835643ee970b2c059dbfe4eb5d751e16c693c8baee61c526abd209e5c7",
+                "sha256:49a8ed515f26913049113820b462f698e6ed26df62c389dafb6fa3685ddca8de",
+                "sha256:74ac8521a0480f228549be20bea555ae35678f0e754c2fbc6f1576b0959bec43",
+                "sha256:89399ca8ecd4524f974e926d4ef9e7a787903e01f0a9cdff3131ad1361792fe5",
+                "sha256:8f291e0338d519a1a0d07f0b9d03c9265f6be26eb32fdd21af6d3259d14ea49c",
+                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
+                "sha256:d3bbd726c1a760d4ca596a4d450c380b81737612fe0182f5bb3caebc17461fd9",
+                "sha256:dea873d6c907c1cf1341fd88742a61efce33227d7743cb37564ab7d7e77dd9fd",
+                "sha256:ded5eea5cb88bc1ce9aa074b5a3092f95ce4741887e317e9b49c7ece75d7ea0e",
+                "sha256:e8b69ea2200d42201cbedd486eedb8980f320d4534f83ce2fb468e96aa5545d0",
+                "sha256:edad117649643230493aeb4955456ce19ab4b12e94489dde6f7094cdb5a3c87e",
+                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
+            ],
+            "version": "==0.4.4"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:077250b34432520430bc1c80dcbda4e354090785567c33ded35faa6df8d24753",
+                "sha256:0da2f947e8ad2697e86fe5fd0e55a4093a2fd79d839c9e19c34e28097db7002c",
+                "sha256:35ff894a0b5df8e28b700126b2869c7dcfb2b2db5bc82e5d5e82547069241553",
+                "sha256:44688b94841349648b1e1a5a7a3d96e6596d5d4f21d0b59a82307e153c4dc74b",
+                "sha256:833716dde880a7f2f2ccdeea9a096842626981ff2a477d8b318c0906367ac11b",
+                "sha256:a0cf3e1842e7c60fde97cb22d275eb6f9524f5c5250489e292529de841417547",
+                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e",
+                "sha256:a728bb9502d1fdc104c66f24a176b6a70a32e89d1d8a5b55c959233ed51c67be",
+                "sha256:c30a098435ea0989c37005a971843e9d3966c7f6d056ddbf052e5061c06e3291",
+                "sha256:c355a45b32c5bc1d9893eceb704b0cfcd1126f91b5a7b9ee64c1c05383283381",
+                "sha256:e64679de1940f41ead5170fce364d54e7b9e2e862f064727b6bcb5cee753b7a2",
+                "sha256:ed71d20225c356881c29f0b1d7a0d6521563a389d9478e8f95d798cc5ba07b88",
+                "sha256:f183f0940b9f5ed2ad9d04c80cab2451440fa9af4fc959d85113fadd2e777962"
+            ],
+            "version": "==0.2.2"
+        },
         "pycparser": {
             "hashes": [
                 "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
@@ -274,6 +351,30 @@
             ],
             "index": "pypi",
             "version": "==2.1.1"
+        },
+        "pynacl": {
+            "hashes": [
+                "sha256:05c26f93964373fc0abe332676cb6735f0ecad27711035b9472751faa8521255",
+                "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c",
+                "sha256:0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e",
+                "sha256:1c780712b206317a746ace34c209b8c29dbfd841dfbc02aa27f2084dd3db77ae",
+                "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621",
+                "sha256:2d23c04e8d709444220557ae48ed01f3f1086439f12dbf11976e849a4926db56",
+                "sha256:30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39",
+                "sha256:37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310",
+                "sha256:4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1",
+                "sha256:57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a",
+                "sha256:5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786",
+                "sha256:6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b",
+                "sha256:7d3ce02c0784b7cbcc771a2da6ea51f87e8716004512493a2b69016326301c3b",
+                "sha256:a14e499c0f5955dcc3991f785f3f8e2130ed504fa3a7f44009ff458ad6bdd17f",
+                "sha256:a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20",
+                "sha256:aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415",
+                "sha256:bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715",
+                "sha256:e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1",
+                "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
+            ],
+            "version": "==1.3.0"
         },
         "pyreleaser": {
             "hashes": [
@@ -319,6 +420,13 @@
                 "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
             ],
             "version": "==0.8.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
         },
         "six": {
             "hashes": [
@@ -370,6 +478,14 @@
             ],
             "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
+        },
+        "uritemplate": {
+            "hashes": [
+                "sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd",
+                "sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd",
+                "sha256:c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d"
+            ],
+            "version": "==3.0.0"
         },
         "urllib3": {
             "hashes": [

--- a/appsecrets/crypto/ejson.py
+++ b/appsecrets/crypto/ejson.py
@@ -1,0 +1,44 @@
+from base64 import b64decode
+import binascii
+import json
+import os
+from typing import Optional
+
+import nacl.public
+
+from . import _Crypto
+
+
+class EJSON(_Crypto):
+
+    _DEFAULT_PRIVATE_KEY_DIR = '/opt/ejson/keys'
+
+    def __init__(self, public_key: str) -> None:
+        self._public_key = public_key
+        self._private_key_dir = os.environ.get('EJSON_KEYDIR') or self._DEFAULT_PRIVATE_KEY_DIR
+        self._private_key: Optional[bytes] = None
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        raise NotImplementedError("Encrypting secrets in ejson is not supported")
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        header, b64_encpub, b64_nonce, b64_box = ciphertext.split(b':')
+        encpub = b64decode(b64_encpub)
+        nonce = b64decode(b64_nonce)
+        box = b64decode(b64_box)
+        b = nacl.public.Box(nacl.public.PrivateKey(self._get_private_key()), nacl.public.PublicKey(encpub))
+        return b.decrypt(box, nonce)  # type: ignore
+
+    def _get_private_key(self) -> bytes:
+        if self._private_key is None:
+            self._private_key = self._load_private_key()
+        return self._private_key
+
+    def _load_private_key(self) -> bytes:
+        path = os.path.join(self._private_key_dir, self._public_key)
+        with open(path) as fh:
+            data = fh.read()
+        private_key = binascii.unhexlify(data.strip())
+        if len(private_key) != 32:
+            raise IOError('invalid private key')
+        return private_key

--- a/appsecrets/crypto/ejson.py
+++ b/appsecrets/crypto/ejson.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 import binascii
-import json
 import os
 from typing import Optional
 
@@ -13,6 +12,8 @@ class EJSON(_Crypto):
 
     _DEFAULT_PRIVATE_KEY_DIR = '/opt/ejson/keys'
 
+    _VALID_HEADER = b'EJ[1'  # https://github.com/Shopify/ejson/blob/master/crypto/boxed_message.go
+
     def __init__(self, public_key: str) -> None:
         self._public_key = public_key
         self._private_key_dir = os.environ.get('EJSON_KEYDIR') or self._DEFAULT_PRIVATE_KEY_DIR
@@ -23,6 +24,8 @@ class EJSON(_Crypto):
 
     def decrypt(self, ciphertext: bytes) -> bytes:
         header, b64_encpub, b64_nonce, b64_box = ciphertext.split(b':')
+        if header != self._VALID_HEADER:
+            raise ValueError(f'invalid header EJSON cypher "{header}", only supporting "{self._VALID_HEADER}"')
         encpub = b64decode(b64_encpub)
         nonce = b64decode(b64_nonce)
         box = b64decode(b64_box)

--- a/appsecrets/stores.py
+++ b/appsecrets/stores.py
@@ -39,9 +39,47 @@ def build(path: str) -> _Store:
     if not Path(path).exists():
         raise Error("The specified path doesn't exist: %s" % path)
 
+    if path.endswith('.ejson'):
+        return EJSONStore(path)
+
     if not Path(path).is_dir():
         raise Error("The only supported secret store is a directory")
     return DirStore(path)
+
+
+class EJSONStore(_Store):
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._crypto = self._load_crypto()
+
+    def encrypt_inplace(self) -> None:
+        raise NotImplementedError()
+
+    def decrypt(self, name: str) -> bytes:
+        content = self._load()
+        try:
+            encrypted = content[name]
+        except KeyError:
+            raise SecretNotFound(name)
+        return self._crypto.decrypt(encrypted)
+
+    def list_encrypted(self) -> Sequence[str]:
+        raise NotImplementedError()
+
+    def list_unencrypted(self) -> Sequence[str]:
+        raise NotImplementedError()
+
+    def _load(self) -> dict:
+        with open(self._path) as fh:
+            data = json.load(fh)
+        assert isinstance(data, dict)
+        return data
+
+    def _load_crypto(self) -> _Crypto:
+        public_key = self._load()['_public_key']
+        return EJSON(public_key=public_key)
+
 
 
 class DirStore(_Store):
@@ -109,6 +147,3 @@ class DirStore(_Store):
 
     def _encrypted_secret_file(self, name: str) -> Path:
         return Path(self._path).joinpath(name + '.enc')
-
-
-

--- a/appsecrets/stores.py
+++ b/appsecrets/stores.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Sequence
 
 from .crypto import _Crypto
+from .crypto.ejson import EJSON
 from .crypto.google_kms import GoogleKMS
 from .crypto.dummy import Dummy
 from .exc import Error, SecretError
@@ -62,7 +63,7 @@ class EJSONStore(_Store):
             encrypted = content[name]
         except KeyError:
             raise SecretNotFound(name)
-        return self._crypto.decrypt(encrypted)
+        return self._crypto.decrypt(bytes(encrypted, 'utf-8'))
 
     def list_encrypted(self) -> Sequence[str]:
         raise NotImplementedError()
@@ -71,8 +72,7 @@ class EJSONStore(_Store):
         raise NotImplementedError()
 
     def _load(self) -> dict:
-        with open(self._path) as fh:
-            data = json.load(fh)
+        data = json.loads(Path(self._path).read_bytes())
         assert isinstance(data, dict)
         return data
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,5 @@
 up:
   - python: 3.6.4
-  - python_develop
   - pipfile
 
 commands:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
     install_requires=[
         'google-api-python-client ~= 1.7.0',
     ],
+    extras_require={
+        'ejson': ['PyNaCl ~= 1.3.0'],
+    },
     entry_points={
         'console_scripts': ['appsecrets = appsecrets.cli:main'],
     },

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
     ],
-    keywords='secrets kms crypto',
+    keywords='secrets kms crypto config ejson',
     author="Pior Bastida",
     author_email="pior@pbastida.net",
     url="https://github.com/pior/appsecrets",

--- a/tests/integration/test_ejson.py
+++ b/tests/integration/test_ejson.py
@@ -1,0 +1,50 @@
+import base64
+
+import pytest
+
+import appsecrets
+
+
+TEST_PRIV = 'ccf94c1cc911ec62994ba53ba728379a307f584c33d1061b9872c7aad5754326'
+TEST_PUB = 'b8f6821146674779489adb3ce1397f979eaf5d7ae2c891d74267190641c9e10b'
+
+TEST_EJSON_FILE = '''
+{
+  "_public_key": "b8f6821146674779489adb3ce1397f979eaf5d7ae2c891d74267190641c9e10b",
+  "_not_encrypted": "NOT_SECRET",
+  "encrypted": "EJ[1:uwAKLP3KaYiKfKNjZ+bWMEgJwMoBKi91WJzLSfMBo3w=:Q+GtbFj6gQogN2BXybi1kw3sWOdvAtpC:sEJ+i1BE8GZTuk4sjIFOcsSE/kyHkw==]",
+  "with_space": "EJ[1:uwAKLP3KaYiKfKNjZ+bWMEgJwMoBKi91WJzLSfMBo3w=:/G/9ZZhFld8yLUA5uxdLmkM6xrP40EP+:DKEmNj/xPBs4309bnnEJ8pbizpALTyOn]",
+  "nested": {
+  	"encrypted": "EJ[1:uwAKLP3KaYiKfKNjZ+bWMEgJwMoBKi91WJzLSfMBo3w=:L3hid20srRC6zHL3zxt5Z4q7U31CHFcW:axvgi39VBYVS2oLJS76ihjtn2whXzA==]"
+  }
+}
+'''
+
+@pytest.fixture
+def ejsonfile(secretsdir):
+    f = secretsdir.join('somefile.ejson')
+    f.write(TEST_EJSON_FILE)
+    return f
+
+
+@pytest.fixture(autouse=True)
+def setup_keydir(tmpdir, secretsdir, ejsonfile, monkeypatch):
+    ejson_keydir = tmpdir.mkdir('ejson_keydir')
+    ejson_keydir.join(TEST_PUB).write(TEST_PRIV)
+    monkeypatch.setenv('EJSON_KEYDIR', str(ejson_keydir))
+
+
+def test_encrypt(secretsdir, ejsonfile, cmd):
+    value = appsecrets.Secrets(path=str(ejsonfile)).decrypt('encrypted')
+    assert value == 'SECRET'
+
+
+def test_decrypt(secretsdir, ejsonfile, cmd):
+    value = appsecrets.Secrets(path=str(ejsonfile)).decrypt('encrypted')
+    assert value == 'SECRET'
+
+
+def test_file_not_found(secretsdir, cmd):
+    with pytest.raises(appsecrets.exc.Error) as exc:
+        appsecrets.Secrets(path=str(secretsdir.join('nofile.ejson')))
+    assert "The specified path doesn't exist" in str(exc.value)

--- a/tests/integration/test_ejson.py
+++ b/tests/integration/test_ejson.py
@@ -35,13 +35,13 @@ def setup_keydir(tmpdir, secretsdir, ejsonfile, monkeypatch):
 
 
 def test_encrypt(secretsdir, ejsonfile, cmd):
-    value = appsecrets.Secrets(path=str(ejsonfile)).decrypt('encrypted')
-    assert value == 'SECRET'
+    with pytest.raises(NotImplementedError):
+        appsecrets.Secrets(path=str(ejsonfile)).encrypt_all()
 
 
 def test_decrypt(secretsdir, ejsonfile, cmd):
     value = appsecrets.Secrets(path=str(ejsonfile)).decrypt('encrypted')
-    assert value == 'SECRET'
+    assert value == b'SECRET'
 
 
 def test_file_not_found(secretsdir, cmd):


### PR DESCRIPTION
- Add a EJSON file store 
- Import code from https://github.com/pior/ecfg
- The EJSON python deps are specified as a `ejson` setuptools extra

Missing: 
- Handle the situation were the `ejson` deps are missing
- Some test coverage