### PR TITLE
Add a PEP-561 marker to say the package contains type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url="https://github.com/pior/appsecrets",
     license="MIT",
     packages=find_packages(),
+    package_data={'appsecrets': ['py.typed']},
     include_package_data=True,
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
> If you would like to publish a library package to a package repository (e.g. PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed in their package directory.

Support in Mypy : https://mypy.readthedocs.io/en/latest/installed_packages.html
The PEP: https://www.python.org/dev/peps/pep-0561/
